### PR TITLE
Fix issue with graceful-fs in versions <4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "react-native-dotenv": "^0.2.0",
     "react-test-renderer": "16.10.2"
   },
+  "resolutions": {
+    "graceful-fs": "4.2.4"
+  },
   "jest": {
     "preset": "react-native",
     "setupFiles": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,10 +3462,10 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+graceful-fs@4.2.4, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 graphlib@^2.1.1, graphlib@^2.1.5:
   version "2.1.7"


### PR DESCRIPTION
Potential fix for a TypeError cause by `graceful-fs`. Remember to run `npm clean cache —force` before rebuilding and running the project.

The fix was successfully tested on:
- macOS 10.15.7
- Node.js v12.18.4
- npm v6.14.8
- yarn v1.22.10